### PR TITLE
feat: register graphical tools on server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
   registerNoteResources,
   registerStatisticResources,
 } from './resources/index.js';
-import { registerConsolidatedTools } from './tools/index.js';
+import { registerConsolidatedTools, registerGraphicalTools } from './tools/index.js';
 
 function createServer(): McpServer {
   const server = new McpServer({
@@ -29,6 +29,9 @@ function createServer(): McpServer {
 
   // Register consolidated tools (6 high-level tools following MCP best practices)
   registerConsolidatedTools(server);
+
+  // Register graphical/GUI tools (issue #3)
+  registerGraphicalTools(server);
 
   return server;
 }


### PR DESCRIPTION
## Summary
- Wires `registerGraphicalTools(server)` into `createServer()` so `gui_current_card` and the other graphical tools (already implemented in `src/tools/graphical.ts`) appear alongside the consolidated tools. Resolves #3.

## Test plan
- [ ] `pnpm typecheck && pnpm lint && pnpm build` pass
- [ ] `pnpm inspect` against a running Anki + AnkiConnect lists `gui_current_card`
- [ ] `gui_current_card` returns the currently-open card